### PR TITLE
DM-25407: ap_verify cannot handle curated crosstalk data in Gen 2

### DIFF
--- a/config/datasetIngest.py
+++ b/config/datasetIngest.py
@@ -5,4 +5,4 @@ config.refcats = {
 
 for ingester in [config.dataIngester, config.calibIngester]:
     ingester.parse.extnames = ['S22', 'S26', 'N25', 'N29', ]
-config.defectIngester.parse.extnames = []
+config.curatedCalibIngester.parse.extnames = []


### PR DESCRIPTION
This PR edits `datasetIngest.py` for the changes made to `DatasetIngestConfig` in lsst/ap_verify#91.