### PR TITLE
DM-27165: Calibration ingestion produces registry where butler cannot find matching calib product

### DIFF
--- a/config/datasetIngest.py
+++ b/config/datasetIngest.py
@@ -6,3 +6,8 @@ config.refcats = {
 for ingester in [config.dataIngester, config.calibIngester]:
     ingester.parse.extnames = ['S22', 'S26', 'N25', 'N29', ]
 config.curatedCalibIngester.parse.extnames = []
+
+# This option allows "community pipeline produced" calibrations to be
+# ingested correctly, preventing the case in which some dates are
+# unable to find the correct calibration.
+config.calibIngester.register.incrementValidEnd = False


### PR DESCRIPTION
Do not increment the validEnd on calib ingest.