### PR TITLE
DM-27857: Update ap_verify dataset conversion scripts

### DIFF
--- a/config/convertRepo_calibs.py
+++ b/config/convertRepo_calibs.py
@@ -4,4 +4,3 @@ config.datasetIgnorePatterns = ["raw", "*Coadd_skyMap", "ref_cat", "defects", "c
 
 # Already stored in convertRepo_templates.py
 config.doRegisterInstrument = False
-config.doWriteCuratedCalibrations = False

--- a/config/convertRepo_copied.py
+++ b/config/convertRepo_copied.py
@@ -8,4 +8,3 @@ for refcat in config.refCats:
 
 # Already stored in convertRepo_templates.py
 config.doRegisterInstrument = False
-config.doWriteCuratedCalibrations = False


### PR DESCRIPTION
This PR updates the Gen 3 conversion configs to be consistent with lsst-dm/ap_verify_dataset_template#19. It does not update the Gen 3 repository, as we can't process this dataset at the moment.