### PR TITLE
DM-21888: Stand up Gen3 version of ap_verify HiTS (2015) CI test

### DIFF
--- a/config/calibrate.py
+++ b/config/calibrate.py
@@ -21,9 +21,10 @@ config.connections.photoRefCat = "panstarrs"
 config.photoRefObjLoader.ref_dataset_name = config.connections.photoRefCat
 config.photoRefObjLoader.filterMap = {
     "u": "g",
-    "g": "g",
-    "r": "r",
-    "i": "i",
-    "z": "z",
-    "y": "y",
+    # TODO: workaround for DM-29186
+    # "g": "g",
+    # "r": "r",
+    # "i": "i",
+    # "z": "z",
+    # "y": "y",
     "VR": "g"}


### PR DESCRIPTION
This PR removes some config lines that were causing crashes in Gen 3. The lines should not affect program behavior, but are preferred for readability.