### PR TITLE
DM-30199: Mark ap_verify dataset files as generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,3 +10,7 @@ preloaded/templates/ !filter !diff !merge
 
 # Too small to be worth tracking
 scripts/rows_as_votable_1500407676_2451.vot.gz !filter !diff !merge
+
+# Must be updated any time Gen 3 repository is updated, but most changes
+# are not human-meaningful.
+config/export.yaml linguist-generated=true


### PR DESCRIPTION
This PR flags `config/export.yaml` as a machine-generated file. The primary benefit of doing so is that it will no longer appear as reviewable changes in repository updates.