### PR TITLE
DM-29857: Create pure Gen 3 dataset management scripts for ap_verify datasets

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,1 +1,1 @@
-Copyright 2018, 2019, 2021 University of Washington
+Copyright 2018, 2019, 2021-2022 University of Washington

--- a/scripts/generate_all_gen3.sh
+++ b/scripts/generate_all_gen3.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+# This file is part of ap_verify_ci_hits2015.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+# Script for regenerating a complete Gen 3 repository in preloaded/.
+# It takes roughly 10 hours to run on lsst-devl.
+#
+# Example:
+# $ nohup generate_all_gen3.sh -c "u/me/DM-123456" &
+# fills this dataset, using collections prefixed by u/me/DM-123456 in
+# /repo/main as a staging area. See generate_all_gen3.sh -h for more options.
+
+
+# Abort script on any error
+set -e
+
+SCRIPT_DIR="$( dirname -- "${BASH_SOURCE[0]}" )"
+DATASET_REPO="${AP_VERIFY_CI_HITS2015_DIR:?'dataset is not set up'}/preloaded/"
+
+
+########################################
+# Command-line options
+
+print_error() {
+    >&2 echo "$@"
+}
+
+usage() {
+    print_error
+    print_error "Usage: $0 [-b BUTLER_REPO] -c ROOT_COLLECTION [-h]"
+    print_error
+    print_error "Specific options:"
+    print_error "   -b          Butler repo URI, defaults to /repo/main"
+    print_error "   -c          unique base collection name for processing; will also appear in final repo"
+    print_error "   -h          show this message"
+    exit 1
+}
+
+parse_args() {
+    while getopts "b:c:h" option $@; do
+        case "$option" in
+            b)  SCRATCH_REPO="$OPTARG";;
+            c)  COLLECT_ROOT="$OPTARG";;
+            h)  usage;;
+            *)  usage;;
+        esac
+    done
+    if [[ -z "${SCRATCH_REPO}" ]]; then
+        SCRATCH_REPO="/repo/main"
+    fi
+    if [[ -z "${COLLECT_ROOT}" ]]; then
+        print_error "$0: mandatory argument -- c"
+        usage
+        exit 1
+    fi
+}
+parse_args $@
+
+
+CALIB_COLLECTION_SCI="${COLLECT_ROOT}-calib-science"
+CALIB_COLLECTION_TMP="${COLLECT_ROOT}-calib-template"
+TEMPLATE_COLLECTION="${COLLECT_ROOT}-template"
+REPO_COLLECTION="refcats"
+
+
+########################################
+# Prepare calibs
+
+"${SCRIPT_DIR}/generate_calibs_gen3_science.sh" -b ${SCRATCH_REPO} -c "${CALIB_COLLECTION_SCI}"
+
+
+########################################
+# Prepare templates
+
+"${SCRIPT_DIR}/generate_calibs_gen3_template.sh" -b ${SCRATCH_REPO} -c "${CALIB_COLLECTION_TMP}"
+"${SCRIPT_DIR}/generate_templates_gen3.sh" -b ${SCRATCH_REPO} -c "${CALIB_COLLECTION_TMP}-calib" \
+    -o "${TEMPLATE_COLLECTION}"
+
+
+########################################
+# Repository creation
+
+"${SCRIPT_DIR}/make_preloaded.sh"
+
+
+########################################
+# Import calibs, templates, and refcats
+
+"${SCRIPT_DIR}/import_calibs_gen3.sh" -b ${SCRATCH_REPO} -c "${CALIB_COLLECTION_SCI}-calib"
+python "${SCRIPT_DIR}/import_templates_gen3.py" -b ${SCRATCH_REPO} -t "${TEMPLATE_COLLECTION}"
+python "${SCRIPT_DIR}/generate_refcats_gen3.py" -b ${SCRATCH_REPO} -i "${REPO_COLLECTION}"
+
+
+########################################
+# Final clean-up
+
+butler collection-chain "${DATASET_REPO}" refcats refcats/imported
+butler collection-chain "${DATASET_REPO}" DECam/defaults templates/deep skymaps DECam/calib refcats
+python "${SCRIPT_DIR}/make_preloaded_export.py" --dataset ap_verify_ci_hits2015
+
+echo "Gen 3 preloaded repository complete."
+echo "All preloaded data products are accessible through the DECam/defaults collection."

--- a/scripts/generate_calibs_gen3.sh
+++ b/scripts/generate_calibs_gen3.sh
@@ -46,7 +46,7 @@ usage() {
     print_error
     print_error "Specific options:"
     print_error "   -b          Butler repo URI, defaults to /repo/main"
-    print_error "   -c          unique base collection name"
+    print_error "   -c          unique base collection name; will also appear in final repo"
     print_error "   -h          show this message"
     exit 1
 }

--- a/scripts/generate_refcats_gen3.py
+++ b/scripts/generate_refcats_gen3.py
@@ -184,12 +184,12 @@ def _remove_refcat_run(butler, run):
             new_runs = list(refcat_runs)
             new_runs.remove(run)
             butler.registry.setCollectionChain(STD_REFCAT, new_runs)
-    except (lsst.daf.butler.MissingCollectionError, TypeError):
+    except (lsst.daf.butler.registry.MissingCollectionError, TypeError):
         pass  # No STD_REFCAT chain; nothing to do
 
     try:
         butler.removeRuns([run], unstore=True)
-    except lsst.daf.butler.MissingCollectionError:
+    except lsst.daf.butler.registry.MissingCollectionError:
         pass  # Already removed; nothing to do
 
 

--- a/scripts/generate_templates_gen3.sh
+++ b/scripts/generate_templates_gen3.sh
@@ -72,7 +72,7 @@ usage() {
     print_error "Specific options:"
     print_error "   -b          Butler repo URI, defaults to /repo/main"
     print_error "   -c          input calib collection for template processing"
-    print_error "   -o          template collection name"
+    print_error "   -o          template collection name; will also appear in final repo"
     print_error "   -h          show this message"
     exit 1
 }

--- a/scripts/import_calibs_gen3.sh
+++ b/scripts/import_calibs_gen3.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+# This file is part of ap_verify_ci_hits2015.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+# Script for importing certified calibs from a work repository.
+#
+# Example:
+# $ import_calibs_gen3 -c "u/me/DM-123456-calib"
+# imports certified calibs from u/me/DM-123456-calib in /repo/main to
+# DECam/calib in this dataset's preloaded repo. See
+# import_calibs_gen3.sh -h for more options.
+
+
+# Abort script on any error
+set -e
+
+
+########################################
+# Command-line options
+
+print_error() {
+    >&2 echo "$@"
+}
+
+usage() {
+    print_error
+    print_error "Usage: $0 [-b BUTLER_REPO] -c CALIB_COLLECTION [-h]"
+    print_error
+    print_error "Specific options:"
+    print_error "   -b          Source Butler repo URI, defaults to /repo/main"
+    print_error "   -c          Source calib collection name"
+    print_error "   -h          show this message"
+    exit 1
+}
+
+parse_args() {
+    while getopts "b:c:h" option $@; do
+        case "$option" in
+            b)  SRC_REPO="$OPTARG";;
+            c)  CALIB_SRC="$OPTARG";;
+            h)  usage;;
+            *)  usage;;
+        esac
+    done
+    if [[ -z "${SRC_REPO}" ]]; then
+        SRC_REPO="/repo/main"
+    fi
+    if [[ -z "${CALIB_SRC}" ]]; then
+        print_error "$0: mandatory argument -- c"
+        usage
+        exit 1
+    fi
+}
+parse_args "$@"
+
+
+########################################
+# Export/Import
+
+CALIB_COLLECT="DECam/calib"
+DATASET_REPO="${AP_VERIFY_CI_HITS2015_DIR:?'dataset is not set up'}/preloaded/"
+STORAGE_DIR="${PWD}/tmp_import"
+
+if [[ -d "$STORAGE_DIR" ]]; then
+    # Left over from a failed run
+    rm -rf "$STORAGE_DIR"
+fi
+
+echo "Transferring calibs..."
+butler export-calibs "$SRC_REPO" "$STORAGE_DIR" "$CALIB_SRC"
+butler import "$DATASET_REPO" "$STORAGE_DIR" --transfer copy \
+    --skip-dimensions instrument,detector,physical_filter
+rm -rf "$STORAGE_DIR"
+
+# Calibs were imported into another collection named $CALIB_SRC.
+butler collection-chain "$DATASET_REPO" "$CALIB_COLLECT" "$CALIB_SRC" --mode prepend
+
+
+########################################
+# Final summary
+
+echo "Calibs stored in ${DATASET_REPO}:${CALIB_COLLECT}"

--- a/scripts/import_templates_gen3.py
+++ b/scripts/import_templates_gen3.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python
+# This file is part of ap_verify_ci_hits2015.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Script for copying templates appropriate for these fields.
+
+The datasets can be from any source, including the generate_templates_gen3.sh
+script in this directory.
+
+Example:
+$ python import_templates_gen3.py -t "u/me/DM-123456-template"
+imports deep templates from u/me/DM-123456-template in /repo/main to
+templates/deep in this dataset's preloaded repo. See
+generate_templates_gen3.sh -h for more options.
+"""
+
+import argparse
+import logging
+import os
+import sys
+import tempfile
+
+import lsst.log
+import lsst.skymap
+from lsst.daf.butler import Butler, CollectionType
+
+
+logging.basicConfig(level=logging.INFO, stream=sys.stdout)
+lsst.log.configure_pylog_MDC("DEBUG", MDC_class=None)
+
+
+########################################
+# Command-line options
+
+def _make_parser():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-b", dest="src_dir", default="/repo/main",
+                        help="Repo to import from, defaults to '/repo/main'.")
+    parser.add_argument("-t", dest="src_collection", required=True,
+                        help="Template collection to import from.")
+    return parser
+
+
+args = _make_parser().parse_args()
+
+
+########################################
+# Export/Import
+
+TEMPLATE_TYPE = "deep"
+TEMPLATE_NAME = TEMPLATE_TYPE + "Coadd"
+TEMPLATE_COLLECT = "templates/" + TEMPLATE_TYPE
+DATASET_REPO = os.path.join(os.environ["AP_VERIFY_CI_HITS2015_DIR"], "preloaded")
+
+
+def _export(butler, export_file):
+    """Export the files to be copied.
+
+    Parameters
+    ----------
+    butler : `lsst.daf.butler.Butler`
+        A Butler pointing to the repository and collection(s) to be
+        exported from.
+    export_file : `str`
+        A path pointing to a file to contain the export results.
+
+    Returns
+    -------
+    runs : iterable [`str`]
+        The names of the runs containing exported templates.
+    """
+    skymaps = butler.registry.queryDataIds("skymap", datasets=TEMPLATE_NAME, collections=butler.collections)
+    skymap_query = f"skymap IN ({', '.join(repr(id['skymap']) for id in skymaps)})"
+    with butler.export(filename=export_file, transfer=None) as contents:
+        contents.saveDatasets(
+            butler.registry.queryDatasets(
+                "skyMap", collections=lsst.skymap.BaseSkyMap.SKYMAP_RUN_COLLECTION_NAME,
+                findFirst=True, where=skymap_query),
+            elements=set())
+        templates = butler.registry.queryDatasets(TEMPLATE_NAME, collections=butler.collections,
+                                                  findFirst=True)
+        contents.saveDatasets(templates)
+        # Do not save butler.collections -- if they are RUN collections, it's
+        # redundant; if they are CHAINED, they likely contain content that
+        # isn't being transferred.
+        return {t.run for t in templates}
+
+
+def _import(butler, export_file, base_dir):
+    """Import the exported files.
+
+    Parameters
+    ----------
+    butler : `lsst.daf.butler.Butler`
+        A Butler pointing to the dataset repository.
+    export_file : `str`
+        A path pointing to a file containing the export results.
+    base_dir : `str`
+        The base directory for the file locations in ``export_file``.
+    """
+    butler.import_(directory=base_dir, filename=export_file, transfer="copy")
+
+
+with tempfile.NamedTemporaryFile(suffix=".yaml") as export_file:
+    src = Butler(args.src_dir, collections=args.src_collection, writeable=False)
+    runs = _export(src, export_file.name)
+    dest = Butler(DATASET_REPO, writeable=True)
+    _import(dest, export_file.name, args.src_dir)
+    dest.registry.registerCollection(TEMPLATE_COLLECT, CollectionType.CHAINED)
+    dest.registry.setCollectionChain(TEMPLATE_COLLECT, runs)
+
+logging.info(f"Templates stored in {DATASET_REPO}:{TEMPLATE_COLLECT}.")

--- a/scripts/make_preloaded.sh
+++ b/scripts/make_preloaded.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# This file is part of ap_verify_ci_hits2015.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+# Script for generating a fresh Gen 3 repository in preloaded/. The previous
+# copy is removed.
+
+
+# Abort script on any error
+set -e
+
+
+########################################
+# Repository creation
+
+REPO_DIR="${AP_VERIFY_CI_HITS2015_DIR:?'dataset is not set up'}/preloaded/"
+
+rm -rf "$REPO_DIR"
+butler create "$REPO_DIR" --standalone
+butler register-instrument "$REPO_DIR" lsst.obs.decam.DarkEnergyCamera
+echo "Created fresh repo in ${REPO_DIR}."
+
+
+########################################
+# Minimal contents
+
+STD_CALIB="DECam/calib"
+CURATED_CALIB="${STD_CALIB}/curated"
+
+# TODO: this step may become unneccessary after DM-32975.
+butler write-curated-calibrations "$REPO_DIR" lsst.obs.decam.DarkEnergyCamera \
+    --collection "$CURATED_CALIB"
+butler collection-chain "$REPO_DIR" "$STD_CALIB" "$CURATED_CALIB"
+echo "Added curated calibrations to ${REPO_DIR}."

--- a/scripts/make_preloaded_export.py
+++ b/scripts/make_preloaded_export.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+
+import argparse
+import logging
+import os
+import sys
+
+import lsst.log
+import lsst.skymap
+import lsst.daf.butler as daf_butler
+import lsst.ap.verify as ap_verify
+
+
+def _make_parser():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dataset", required=True,
+                        help="The name of the dataset as recognized by ap_verify.py.")
+    return parser
+
+
+def main():
+    # Ensure logs from tasks are visible
+    logging.basicConfig(level=logging.INFO, stream=sys.stdout)
+    lsst.log.configure_pylog_MDC("DEBUG", MDC_class=None)
+
+    args = _make_parser().parse_args()
+    dataset = ap_verify.dataset.Dataset(args.dataset)
+    gen3_repo = os.path.join(dataset.datasetRoot, "preloaded")
+
+    logging.info("Exporting Gen 3 registry to configure new repos...")
+    _export_for_copy(dataset, gen3_repo)
+
+
+def _export_for_copy(dataset, repo):
+    """Export a Gen 3 repository so that a dataset can make copies later.
+
+    Parameters
+    ----------
+    dataset : `lsst.ap.verify.dataset.Dataset`
+        The dataset needing the ability to copy the repository.
+    repo : `str`
+        The location of the Gen 3 repository.
+    """
+    butler = daf_butler.Butler(repo)
+    with butler.export(directory=dataset.configLocation, format="yaml") as contents:
+        # Need all detectors, even those without data, for visit definition
+        contents.saveDataIds(butler.registry.queryDataIds({"detector"}).expanded())
+        contents.saveDatasets(butler.registry.queryDatasets(datasetType=..., collections=...))
+        # Explicitly save the calibration and chained collections.
+        # Do _not_ include the RUN collections here because that will export
+        # an empty raws collection, which ap_verify assumes does not exist
+        # before ingest.
+        target_types = {daf_butler.CollectionType.CALIBRATION, daf_butler.CollectionType.CHAINED}
+        for collection in butler.registry.queryCollections(..., collectionTypes=target_types):
+            contents.saveCollection(collection)
+        # Export skymap collection even if it is empty
+        contents.saveCollection(lsst.skymap.BaseSkyMap.SKYMAP_RUN_COLLECTION_NAME)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR adds high-level dataset management scripts that call those introduced in #29. It is now possible to regenerate a Gen 3 repository from scratch just by running `generate_all_gen3.sh`.

The scripts provided here do not allow a CI subset to be generated from pipeline products for `ap_verify_hits2015`; this capability will be added in [DM-33095](https://jira.lsstcorp.org/browse/DM-33095).