### PR TITLE
DM-32988: Update all ApPipe pipelines to use multi-tract difference imaging

### DIFF
--- a/config/imageDifference.py
+++ b/config/imageDifference.py
@@ -1,4 +1,4 @@
-# Config override for lsst.pipe.tasks.imageDifference.ImageDifferenceTask
+# Config override for lsst.pipe.tasks.imageDifference.ImageDifferenceFromTemplateTask
 # Templates are deepCoadds assembled with the CompareWarp algorithm
 
 config.connections.coaddName = "deep"

--- a/config/imageDifferenceWithFakes.py
+++ b/config/imageDifferenceWithFakes.py
@@ -1,4 +1,4 @@
-# Config override for lsst.pipe.tasks.imageDifference.ImageDifferenceTask
+# Config override for lsst.pipe.tasks.imageDifference.ImageDifferenceFromFakesTask
 # Templates are deepCoadds assembled with the CompareWarp algorithm
 
 # This file is only needed to provide the explicit "fakes_" connections names

--- a/pipelines/ApPipe.yaml
+++ b/pipelines/ApPipe.yaml
@@ -39,7 +39,7 @@ tasks:
       # Use dataset's reference catalogs
       file: $AP_VERIFY_CI_HITS2015_DIR/config/calibrate.py
   imageDifference:
-    class: lsst.pipe.tasks.imageDifference.ImageDifferenceTask
+    class: lsst.pipe.tasks.imageDifference.ImageDifferenceFromTemplateTask
     config:
       # Use dataset's specific templates
       file: $AP_VERIFY_CI_HITS2015_DIR/config/imageDifference.py

--- a/pipelines/ApVerify.yaml
+++ b/pipelines/ApVerify.yaml
@@ -34,7 +34,7 @@ tasks:
       # Use dataset's reference catalogs
       file: $AP_VERIFY_CI_HITS2015_DIR/config/calibrate.py
   imageDifference:
-    class: lsst.pipe.tasks.imageDifference.ImageDifferenceTask
+    class: lsst.pipe.tasks.imageDifference.ImageDifferenceFromTemplateTask
     config:
       # Use dataset's specific templates
       file: $AP_VERIFY_CI_HITS2015_DIR/config/imageDifference.py

--- a/pipelines/ApVerifyWithFakes.yaml
+++ b/pipelines/ApVerifyWithFakes.yaml
@@ -57,12 +57,12 @@ tasks:
         from lsst.utils import getPackageDir
         config.calibrate.load(os.path.join(getPackageDir("ap_verify_ci_hits2015"), "config", "calibrate.py"))
   imageDifferenceNoFakes:
-    class: lsst.pipe.tasks.imageDifference.ImageDifferenceTask
+    class: lsst.pipe.tasks.imageDifference.ImageDifferenceFromTemplateTask
     config:
       # Use dataset's specific templates
       file: $AP_VERIFY_CI_HITS2015_DIR/config/imageDifference.py
   imageDifference:
-    class: lsst.pipe.tasks.imageDifference.ImageDifferenceTask
+    class: lsst.pipe.tasks.imageDifference.ImageDifferenceFromTemplateTask
     config:
       # Use dataset's specific templates
       file: $AP_VERIFY_CI_HITS2015_DIR/config/imageDifferenceWithFakes.py


### PR DESCRIPTION
Since `ApVerify.yaml` imports `ApPipe.yaml`, which now uses `imageDifferenceFromTemplateTask` instead of `imageDifferenceTask`, we need to keep the dataset-specific pipelines in sync.