### PR TITLE
DM-34249: AP pipeline can't read old ap_verify templates

### DIFF
--- a/ups/ap_verify_ci_hits2015.table
+++ b/ups/ap_verify_ci_hits2015.table
@@ -1,1 +1,4 @@
 setupRequired(obs_decam)
+# TODO: needed for reading old templates
+# Should be removed or updated if DM-28628 updates the templates
+setupRequired(meas_extensions_psfex)


### PR DESCRIPTION
This PR adds a `meas_extensions_psfex` dependency to let us keep reading templates with PSFex PSFs even after the removal of this package from the rest of Science Pipelines.