### PR TITLE
DM-36385: Deprecate ap_verify_hits2015 dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,4 +39,4 @@ However, it can be installed explicitly with the [LSST Software Build Tool](http
     git clone https://github.com/lsst/ap_verify_ci_hits2015/
     setup -r ap_verify_ci_hits2015
 
-See the Science Pipelines documentation for more detailed instructions on [installing datasets](https://pipelines.lsst.io/modules/lsst.ap.verify/datasets-install.html) and [running `ap_verify`](https://pipelines.lsst.io/modules/lsst.ap.verify/running.html). The name of this dataset is `CI-HiTS2015`.
+See the Science Pipelines documentation for more detailed instructions on [installing datasets](https://pipelines.lsst.io/modules/lsst.ap.verify/datasets-install.html) and [running `ap_verify`](https://pipelines.lsst.io/modules/lsst.ap.verify/running.html).

--- a/doc/ap_verify_ci_hits2015/index.rst
+++ b/doc/ap_verify_ci_hits2015/index.rst
@@ -7,8 +7,6 @@ ap_verify_ci_hits2015
 The ``ap_verify_ci_hits2015`` package is a minimal collection of images from the DECam `HiTS`_ survey, formatted for use with :doc:`/modules/lsst.ap.verify/index`.
 It is intended for continuous integration.
 
-A larger version of the same dataset is available from the :doc:`/packages/ap_verify_hits2015/index` package.
-
 .. _HiTS: https://doi.org/10.3847/0004-637X/832/2/155
 
 .. _ap_verify_ci_hits2015-using:

--- a/scripts/generate_calibs_gen3_science.sh
+++ b/scripts/generate_calibs_gen3_science.sh
@@ -30,10 +30,6 @@
 # $ nohup generate_calibs_gen3_science.sh -c "u/me/DM-123456" &
 # produces certified calibs in /repo/main in the u/me/DM-123456-calib
 # collection. See generate_calibs_gen3_science.sh -h for more options.
-#
-# The calibs produced by this script are a subset of those produced by
-# ap_verify_hits2015/scripts/generate_calibs_gen3_science.sh, so if you are
-# running that script, there is no need to run this one as well.
 
 
 # Common definitions

--- a/scripts/generate_calibs_gen3_template.sh
+++ b/scripts/generate_calibs_gen3_template.sh
@@ -29,10 +29,6 @@
 # $ nohup generate_calibs_gen3_template.sh -c "u/me/DM-123456" &
 # produces certified calibs in /repo/main in the u/me/DM-123456-calib
 # collection. See generate_calibs_gen3_template.sh -h for more options.
-#
-# The calibs produced by this script are the same as those produced by
-# ap_verify_hits2015/scripts/generate_calibs_gen3_template.sh, so if you are
-# running that script, there is no need to run this one as well.
 
 
 # Common definitions

--- a/scripts/generate_templates_gen3.sh
+++ b/scripts/generate_templates_gen3.sh
@@ -30,10 +30,6 @@
 # $ nohup generate_templates_gen3.sh -c "u/me/DM-123456-calib" -o "u/me/DM-123456-template" &
 # produces templates in /repo/main in the u/me/DM-123456-template collection.
 # See generate_templates_gen3.sh -h for more options.
-#
-# The templates produced by this script are a subset of those produced by
-# ap_verify_hits2015/scripts/generate_templates_gen3.sh, so if you are running
-# that script, there is no need to run this one as well.
 
 
 # Abort script on any error


### PR DESCRIPTION
This PR removes documentation references to `ap_verify_hits2015` (which is being removed) and `CI-HiTS2015` (which was already removed).