### PR TITLE
DM-37667: Migrate preloaded repo to latest versions.

### DIFF
--- a/config/calibrate.py
+++ b/config/calibrate.py
@@ -3,12 +3,10 @@
 # Use gaia for astrometry (phot_g_mean for everything, as that is the broadest
 # band with the most depth)
 config.connections.astromRefCat = "gaia"
-config.astromRefObjLoader.ref_dataset_name = config.connections.astromRefCat
 config.astromRefObjLoader.anyFilterMapsToThis = "phot_g_mean"
 
 # Use panstarrs for photometry (grizy filters)
 config.connections.photoRefCat = "panstarrs"
-config.photoRefObjLoader.ref_dataset_name = config.connections.photoRefCat
 config.photoRefObjLoader.filterMap = {
     "u": "g",
     "VR": "g"}

--- a/config/export.yaml
+++ b/config/export.yaml
@@ -1,11 +1,14 @@
 description: Butler Data Repository Export
-version: 1.0.1
+version: 1.0.2
+universe_version: 3
+universe_namespace: daf_butler
 data:
 - type: dimension
   element: instrument
   records:
   - name: DECam
     visit_max: 33554432
+    visit_system: 0
     exposure_max: 33554432
     detector_max: 100
     class_name: lsst.obs.decam.DarkEnergyCamera
@@ -407,12 +410,6 @@ data:
     region: !<lsst.sphgeom.ConvexPolygon>
       encoded: 7054ce8ae11956eabf99e86d510683e13fd95d1069ab7cc3bf6fe98e789d9eedbfe5c43a511b2dd63f52926986ab7cc3bfbe74be7799e0edbf1852e9d58e70d63f5a8a9f7255b1b23fd98455e41598eabf32edf40bc0a4e13fe92f966855b1b23f
 - type: dimension
-  element: visit_system
-  records:
-  - instrument: DECam
-    id: 0
-    name: one-to-one
-- type: dimension
   element: exposure
   records:
   - instrument: DECam
@@ -425,6 +422,8 @@ data:
     observation_reason: science
     day_obs: 20150218
     seq_num: 411371
+    seq_start: 411371
+    seq_end: 411371
     group_name: '411371'
     group_id: 411371
     target_name: Blind15A_42
@@ -432,7 +431,9 @@ data:
     tracking_ra: 155.4702849608958
     tracking_dec: -4.950050405424033
     sky_angle: 90.0
+    azimuth: null
     zenith_angle: 25.289999999999992
+    has_simulated: false
     datetime_begin: !butler_time/tai/iso '2015-02-18 05:27:12.433035000'
     datetime_end: !butler_time/tai/iso '2015-02-18 05:29:25.000000000'
   - instrument: DECam
@@ -445,6 +446,8 @@ data:
     observation_reason: science
     day_obs: 20150218
     seq_num: 411420
+    seq_start: 411420
+    seq_end: 411420
     group_name: '411420'
     group_id: 411420
     target_name: Blind15A_40
@@ -452,7 +455,9 @@ data:
     tracking_ra: 155.1202723539563
     tracking_dec: -6.520134270088981
     sky_angle: 90.0
+    azimuth: null
     zenith_angle: 35.09
+    has_simulated: false
     datetime_begin: !butler_time/tai/iso '2015-02-18 07:04:30.532568000'
     datetime_end: !butler_time/tai/iso '2015-02-18 07:06:54.000000000'
   - instrument: DECam
@@ -465,6 +470,8 @@ data:
     observation_reason: science
     day_obs: 20150309
     seq_num: 419802
+    seq_start: 419802
+    seq_end: 419802
     group_name: '419802'
     group_id: 419802
     target_name: Blind15A_40
@@ -472,7 +479,9 @@ data:
     tracking_ra: 155.12015152062799
     tracking_dec: -6.5200784367473155
     sky_angle: 90.0
+    azimuth: null
     zenith_angle: 36.15
+    has_simulated: false
     datetime_begin: !butler_time/tai/iso '2015-03-09 05:55:51.522985000'
     datetime_end: !butler_time/tai/iso '2015-03-09 05:58:23.000000000'
 - type: dimension
@@ -533,13 +542,14 @@ data:
   - instrument: DECam
     id: 411371
     physical_filter: g DECam SDSS c0001 4720.0 1520.0
-    visit_system: 0
     name: ct4m20150218t052637
     day_obs: 20150218
+    seq_num: 411371
     exposure_time: 86.0
     target_name: Blind15A_42
     observation_reason: science
     science_program: 2015A-0608
+    azimuth: null
     zenith_angle: 25.289999999999992
     region: !<lsst.sphgeom.ConvexPolygon>
       encoded: 706d6767f746eeecbf5e0bfb47f3fdda3fc0d67a55e4a6b1bf6ef2cfb75de3ecbf6b2e9fb2c824db3f0ea608dce861b2bfc792b52d38cdecbf2985ee210072db3fd40c9258a6d8b3bff8e290843ac0ecbff013c5dada96db3f532e40abcc4eb5bfeeddb35f69beecbf434809b94295db3f21ef4fd18309b6bf202ab64b4abcecbfe43004d55293db3f2659141763ddb6bf833b40f7e6c1ecbfbf1df52cc467db3f5b0102a8c253b8bf5caa1ab15bc9ecbfa6395bb6ca3ddb3f8b14c135e30eb9bf3d284ed4b2d0ecbf8d58a731b713db3f27146880e0c9b9bf281647f6ecd7ecbf19cb466e89e9da3fafa31e499684babf389145340fececbf272f462f8192da3f2aa863c76885babfa173ec07fdfcecbf204f9c7e5248da3f85608c293d85babf75552ee5a910edbf7037632bdff0d93fc2243309ab84babfb648add3ed26edbf0c0e187db6a3d93ffab14305d90eb9bf3588fc6be431edbf799c3da4fb7cd93f16ecb62c6953b8bf167641d3a83eedbf3355937ff857d93f9082dbf36cddb6bf08f260d98e40edbf5d50b60b9a59d93f865d6dba1122b6bf04c73b049a42edbf46fff1fa835bd93fc32aa40f254eb5bffaab0efe333dedbf8462cee13b87d93f0fcaa18855d8b3bff138019aec35edbfe045905b5bb1d93f5a151a5a251db3bfca37b062852eedbf8cc78fcc6adbd93fbf4c897ccc61b2bf5fbe73530427edbf5608b5c14905da3f451f6d21c8a6b1bf61caf2c75913edbf4f46b52ebf5cda3f5fde573665a6b1bf0d9c2aa1ea00edbfa6d8434c7cadda3f1ef2081d7ba6b1bf
@@ -548,13 +558,14 @@ data:
   - instrument: DECam
     id: 411420
     physical_filter: g DECam SDSS c0001 4720.0 1520.0
-    visit_system: 0
     name: ct4m20150218t070355
     day_obs: 20150218
+    seq_num: 411420
     exposure_time: 86.0
     target_name: Blind15A_40
     observation_reason: science
     science_program: 2015A-0608
+    azimuth: null
     zenith_angle: 35.09
     region: !<lsst.sphgeom.ConvexPolygon>
       encoded: 700d83c88335c8ecbfbe2a014eb448db3f381243a086a4b8bff263cf5b99bcecbf22d5fe95dd6edb3f4cc18883105fb9bfbd8dbad40da5ecbfa448c03fbbbadb3fe8c3a0d8c2d4babfafde352cca96ecbf1fdcee7759dedb3fbe44cb51db49bcbf4a61acf06594ecbfd94d321232dcdb3f88c805321104bdbf896c2e10a091ecbfbf21cb6e9fd9db3f80912f3e59d7bdbf2f693b533596ecbfb57aa1a80eaddb3fc5b949f2b74cbfbfb0cc1b29369decbf103256d1a282db3fa0935c1aad03c0bfe7e0b69b19a4ecbf277226ac1c58db3f70e9ba10e960c0bfb5e1675de0aaecbf257e06257c2ddb3f6ebb5cccfdbdc0bfd8d65fe345bfecbf83d304a9b2d6da3f4362c3066ebec0bfd94b60c66dd0ecbff1ae3666b98cda3f8231414958bec0bf85c7ce665fe4ecbf6f9ee7788435da3f082ac32108bec0bf56d89f8808fcecbfc6e8f23eb5e9d93ffe04e405a803c0bf2c164d48b207edbfcd931c00a7c3d93f8994a9bf5e4cbfbfeb729cb2bc15edbfaea90a8fdf9fd93ffb3e711a63d7bdbfc9b5a0483618edbfc6f3cb1711a2d93fbb7336ce8d1cbdbfd6d81351e81aedbf0df79c939da4d93fb2277f203449bcbfebc2391b8916edbfeed451d457d1d93f25e2962e72d4babf5c605b85b50fedbf3fbaf043eafbd93fd4560412cb19babfbddd164cc208edbfdc90f6676c26da3f46bfdd36f45eb9bf15b6a420b501edbff9cfe683bd50da3f9d23fb796aa4b8bfebb30093c6edecbf816ecf46f5a7da3f526ef56316a4b8bf8010c24f18dbecbf62ef7e4978f8da3fa10510b22ba4b8bf
@@ -563,13 +574,14 @@ data:
   - instrument: DECam
     id: 419802
     physical_filter: g DECam SDSS c0001 4720.0 1520.0
-    visit_system: 0
     name: ct4m20150309t055516
     day_obs: 20150309
+    seq_num: 419802
     exposure_time: 102.0
     target_name: Blind15A_40
     observation_reason: science
     science_program: 2015A-0608
+    azimuth: null
     zenith_angle: 36.15
     region: !<lsst.sphgeom.ConvexPolygon>
       encoded: 70800fc9ce33c8ecbf0fb81e6dbc48db3f32c4805a76a4b8bf43a986a597bcecbff29327b3e56edb3fe3140e3f005fb9bfd27ee81b0ca5ecbf777ae958c3badb3fc67ce896b2d4babf1965a173c896ecbf6737a88f61dedb3fd688db12cb49bcbf8a3c97396494ecbfd4a0822a3adcdb3f67126df40004bdbfd880ce5a9e91ecbf368bc287a7d9db3f76a9260249d7bdbf431da4a33396ecbf123f5fc516addb3f8227ebb8a74cbfbfcefdcc7d349decbfc17944f1aa82db3fe16055fea403c0bfeb11b2f417a4ecbfc1d43ccf2458db3f6a0664f5e060c0bfe853aebadeaaecbf6d863c4b842ddb3f3439beb1f5bdc0bff643a74644bfecbfe3b7dfd4bad6da3f6db314ec65bec0bf8714c42e6cd0ecbfe44dcf96c18cda3f3655922e50bec0bf902e38d55de4ecbf767a02af8c35da3fecc2240700bec0bf135593f906fcecbf12211779bde9d93f4fc8dce99f03c0bf0b3c87bab007edbf9eaa383cafc3d93fec444a864e4cbfbf28129c24bb15edbfe3f586cce79fd93f5e5a68de52d7bdbf4f251fb93418edbf341db65419a2d93fcb8ccb907d1cbdbf7c5bddbfe61aedbf6d6fdacfa5a4d93f8a4e8ee12349bcbfa2ea38848716edbfd7f0d80c60d1d93f9a30deec61d4babf41570feab30fedbf92cc5379f2fbd93f9459e2ceba19babf926b80acc008edbfaf882c9a7426da3fa3e062f2e35eb9bf43cdc77cb301edbfcd05e9b2c550da3f2eaf38345aa4b8bf7c351ce9c4edecbf7a9c4e70fda7da3fda54101e06a4b8bf00634da016dbecbfee53d46d80f8da3f98542c6c1ba4b8bf
@@ -579,15 +591,12 @@ data:
   element: visit_definition
   records:
   - instrument: DECam
-    visit_system: 0
     exposure: 411371
     visit: 411371
   - instrument: DECam
-    visit_system: 0
     exposure: 411420
     visit: 411420
   - instrument: DECam
-    visit_system: 0
     exposure: 419802
     visit: 419802
 - type: dimension
@@ -9077,7 +9086,6 @@ data:
   - band
   - instrument
   - physical_filter
-  - visit_system
   - visit
   storage_class: DataFrame
   is_calibration: false

--- a/pipelines/ApPipe.yaml
+++ b/pipelines/ApPipe.yaml
@@ -2,8 +2,6 @@ description: End to end Alert Production pipeline specialized for HiTS-2015
 #
 # NOTES
 # Remember to run make_apdb.py and use the same configs for diaPipe
-# READ_UNCOMMITTED is required for sqlite APDBs, i.e.,
-# -c diaPipe:apdb.isolation_level: 'READ_UNCOMMITTED'
 # A db_url is always required, e.g.,
 # -c diaPipe:apdb.db_url: 'sqlite:////project/user/association.db'
 # Option to specify connection_timeout for sqlite APDBs encountering lock errors, i.e.,

--- a/preloaded/gen3.sqlite3
+++ b/preloaded/gen3.sqlite3
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d73c2bef4a2ad05643bbe9ce2d7110327e105f53dc9284cb14594e42cacd4cf3
-size 4694016
+oid sha256:46ae5735960f684f3559d5ec6b141afc1af8eac4714b0bd474d5d0fdde62f9c2
+size 4743168


### PR DESCRIPTION
This PR migrates the preloaded repo to current schemas, to prevent the kinds of compatibility problems that interfered with adding ephemerides on lsst/ap_verify_ci_cosmos_pdr2#32.