### PR TITLE
DM-50362: Temporarily load solar system object tables using the old name

### DIFF
--- a/pipelines/ApPipe.yaml
+++ b/pipelines/ApPipe.yaml
@@ -38,3 +38,5 @@ tasks:
     class: lsst.ap.association.DiaPipelineTask
     config:
       doSolarSystemAssociation: true
+      # TODO: remove in DM-50364 when the preloaded datasets are regenerated
+      connections.solarSystemObjectTable: preloaded_SsObjects

--- a/pipelines/ApVerify.yaml
+++ b/pipelines/ApVerify.yaml
@@ -35,3 +35,5 @@ tasks:
     class: lsst.ap.association.DiaPipelineTask
     config:
       doSolarSystemAssociation: true
+      # TODO: remove in DM-50364 when the preloaded datasets are regenerated
+      connections.solarSystemObjectTable: preloaded_SsObjects

--- a/pipelines/ApVerifyWithFakes.yaml
+++ b/pipelines/ApVerifyWithFakes.yaml
@@ -38,3 +38,5 @@ tasks:
     class: lsst.ap.association.DiaPipelineTask
     config:
       doSolarSystemAssociation: true
+      # TODO: remove in DM-50364 when the preloaded datasets are regenerated
+      connections.solarSystemObjectTable: preloaded_SsObjects


### PR DESCRIPTION

****

- [x] Did you run `ap_verify.py` on this dataset?
- [x] If you made changes to `scripts/`, should those changes be propagated to [ap_verify_dataset_template](https://github.com/lsst-dm/ap_verify_dataset_template/), or are they specific to this data set?
- [x] Are the Sphinx documentation and readme up-to-date?
